### PR TITLE
Add UI device ID controls and runtime updates

### DIFF
--- a/cloud/api/device_id.py
+++ b/cloud/api/device_id.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+"""Utilities for working with device identifiers."""
+
+_ALLOWED_CHARS = {"-", "_", "."}
+
+
+def sanitize_device_id(raw: str | None) -> str:
+    """Validate and normalise a device identifier.
+
+    Whitespace is stripped and the identifier must contain at least one character.
+    Only alphanumeric characters plus ``-``, ``_`` and ``.`` are permitted.
+    """
+
+    if raw is None:
+        raise ValueError("Device ID is required")
+
+    candidate = raw.strip()
+    if not candidate:
+        raise ValueError("Device ID cannot be empty")
+
+    for character in candidate:
+        if character.isalnum():
+            continue
+        if character not in _ALLOWED_CHARS:
+            raise ValueError(
+                "Device ID may only contain letters, numbers, dashes, underscores, or periods",
+            )
+
+    return candidate
+
+
+__all__ = ["sanitize_device_id"]

--- a/cloud/web/templates/index.html
+++ b/cloud/web/templates/index.html
@@ -63,7 +63,8 @@
             font-family: inherit;
             font-size: 0.95rem;
         }
-        input[type="number"] {
+        input[type="number"],
+        input[type="text"] {
             width: 120px;
             padding: 0.5rem;
             border-radius: 8px;
@@ -222,6 +223,18 @@
     <main>
         <section class="panels">
             <article class="card">
+                <h2>Device Identity</h2>
+                <p class="muted" style="margin-top:-0.25rem;">Update the device identifier used for API calls.</p>
+                <form id="device-id-form" style="display:flex;flex-direction:column;gap:0.75rem;">
+                    <div style="display:flex;flex-direction:column;gap:0.35rem;">
+                        <label for="device-id-input">Device ID</label>
+                        <input id="device-id-input" type="text" autocomplete="off" spellcheck="false" style="width:100%;" />
+                    </div>
+                    <button type="submit">Save Device ID</button>
+                </form>
+                <div id="device-id-status" class="status"></div>
+            </article>
+            <article class="card">
                 <h2>Normal Condition</h2>
                 <p class="muted" style="margin-top:-0.25rem;">Reference description used for classification context.</p>
                 <form id="normal-form">
@@ -322,6 +335,9 @@
         </section>
     </main>
         <script>
+        const deviceIdForm = document.getElementById('device-id-form');
+        const deviceIdInput = document.getElementById('device-id-input');
+        const deviceIdStatus = document.getElementById('device-id-status');
         const normalForm = document.getElementById('normal-form');
         const normalText = document.getElementById('normal-text');
         const normalStatus = document.getElementById('normal-status');
@@ -352,6 +368,7 @@
             captureLimitInput.value = String(CAPTURE_LIMIT_DEFAULT);
         }
 
+        let isEditingDeviceId = false;
         let isEditingDescription = false;
         let stateTimerId = null;
         let captureTimerId = null;
@@ -447,6 +464,9 @@
                 const response = await fetch('/ui/state');
                 if (!response.ok) throw new Error('Failed to load state');
                 const data = await response.json();
+                if (!isEditingDeviceId && deviceIdInput) {
+                    deviceIdInput.value = data.device_id || '';
+                }
                 if (!isEditingDescription) {
                     normalText.value = data.normal_description || '';
                 }
@@ -646,6 +666,49 @@
                     triggerStatus.textContent = error.message;
                 }
             }
+        }
+
+        if (deviceIdInput) {
+            deviceIdInput.addEventListener('focusin', () => {
+                isEditingDeviceId = true;
+            });
+            deviceIdInput.addEventListener('focusout', () => {
+                isEditingDeviceId = false;
+            });
+        }
+
+        if (deviceIdForm) {
+            deviceIdForm.addEventListener('submit', async (event) => {
+                event.preventDefault();
+                if (!deviceIdInput) {
+                    return;
+                }
+                const deviceId = (deviceIdInput.value || '').trim();
+                if (!deviceId) {
+                    deviceIdStatus.textContent = 'Device ID cannot be empty.';
+                    return;
+                }
+                deviceIdStatus.textContent = 'Saving...';
+                try {
+                    const response = await fetch('/ui/device-id', {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({ device_id: deviceId }),
+                    });
+                    if (!response.ok) {
+                        const errorData = await response.json().catch(() => ({}));
+                        throw new Error(errorData.detail || 'Failed to update device ID');
+                    }
+                    const payload = await response.json();
+                    deviceIdInput.value = payload.device_id || deviceId;
+                    deviceIdStatus.textContent = 'Device ID updated.';
+                    await loadState();
+                } catch (error) {
+                    deviceIdStatus.textContent = error.message;
+                } finally {
+                    isEditingDeviceId = false;
+                }
+            });
         }
 
         normalText.addEventListener('focusin', () => {

--- a/tests/test_device_runtime.py
+++ b/tests/test_device_runtime.py
@@ -1,0 +1,40 @@
+import unittest
+
+from device.main import update_device_identity
+
+
+class DeviceRuntimeTests(unittest.TestCase):
+    def test_update_device_identity_no_change_for_invalid_candidate(self) -> None:
+        metadata = {"device_id": "alpha"}
+        restarted: list[str] = []
+
+        new_id = update_device_identity("alpha", "  ", metadata, restarted.append)
+
+        self.assertEqual(new_id, "alpha")
+        self.assertEqual(metadata["device_id"], "alpha")
+        self.assertFalse(restarted)
+
+    def test_update_device_identity_updates_metadata_and_restarts(self) -> None:
+        metadata = {"device_id": "alpha"}
+        restarted: list[str] = []
+        logs: list[str] = []
+
+        def log(message: str) -> None:
+            logs.append(message)
+
+        new_id = update_device_identity(
+            "alpha",
+            "beta-1",
+            metadata,
+            restarted.append,
+            log=log,
+        )
+
+        self.assertEqual(new_id, "beta-1")
+        self.assertEqual(metadata["device_id"], "beta-1")
+        self.assertEqual(restarted, ["beta-1"])
+        self.assertTrue(any("alpha" in entry and "beta-1" in entry for entry in logs))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add shared device ID sanitisation and persistence support to the API
- expose a UI control and HTTP endpoint for editing the active device identifier
- update the device runtime to react to config-provided device IDs and restart listeners

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d9bcc64878832593024a6f1818fa91